### PR TITLE
Minor improvements

### DIFF
--- a/research.md
+++ b/research.md
@@ -25,7 +25,7 @@ the right refinement spec.
 
 ## Dafny to Go compilation
 
-Native integer types are accessible with `{:nativeType}` on a subset type.
+Native integer types are accessible with `{:nativeType}` on a `newtype` type.
 
 Byte slices are axiomatized as an `{:extern}` class. These have a number of
 operations, but notably we don't have a notion of a slice which is a view into

--- a/tests/bank_test.go
+++ b/tests/bank_test.go
@@ -18,8 +18,6 @@ func TestBankSanity(t *testing.T) {
 	b.Transfer(0, 2)
 	b.Transfer(1, 2)
 
-	assert.True(b.Audit(), "audit failed")
-
 	jrnl := b.Jrnl
 	b = bank.New_Bank_()
 	b.Recover(jrnl)


### PR DESCRIPTION
The invariant `ValidState` was parenthesized incorrectly. However, because `n < 512` is a nonempty range, the meaning in the end was still correct.

Writing `as` casts in both key and value expression in the map comprehensions give a way around the issue in the type inference.

For `Get`, since there is no `modifies` clause, there's no reason to repeat `Valid()` as a postcondition.

`Audit` is better written as a lemma. Note, the way it was written previously, an auditor would be happy only if `b` returns as `true` and the method spec didn't guarantee that.