### PR TITLE
Timeout investigation

### DIFF
--- a/src/Dafny/examples/fs/dirent.dfy
+++ b/src/Dafny/examples/fs/dirent.dfy
@@ -564,7 +564,7 @@ module DirEntries
       zeros_enc(n);
     }
 
-    function extend_zero(n: nat): (dents: Dirents)
+    function {:opaque} extend_zero(n: nat): (dents: Dirents)
       requires Valid()
       requires |s| + n <= dir_sz
       ensures dents.Valid()
@@ -585,6 +585,7 @@ module DirEntries
       requires findFree() >= |s|
       ensures extend_zero(n).findFree() == |s|
     {
+      reveal extend_zero();
       C.find_first_complete(is_unused, s);
       C.find_first_characterization(is_unused, extend_zero(n).s, |s|);
     }
@@ -595,6 +596,7 @@ module DirEntries
       requires findName(p) >= |s|
       ensures extend_zero(n).findName(p) == |extend_zero(n).s|
     {
+      reveal extend_zero();
       C.find_first_complete(findName_pred(p), s);
       var xs := s + C.repeat(DirEnt.zero, n);
       C.find_first_characterization(findName_pred(p), xs, |s| + n);

--- a/src/Dafny/examples/fs/indirect_fs.dfy
+++ b/src/Dafny/examples/fs/indirect_fs.dfy
@@ -196,12 +196,12 @@ module IndFs
     constructor Init(d: Disk)
       ensures ValidQ()
       ensures fresh(Repr)
-      ensures data == imap pos: Pos {:trigger pos.idx.data?} | pos.idx.data? :: block0
+      ensures data == imap pos: Pos {:trigger pos.idx.data?()} | pos.idx.data?() :: block0
       ensures metadata == map ino: Ino {:trigger} :: Inode.Meta(0, Inode.InvalidType)
     {
       this.fs := new Filesys.Init(d);
       this.to_blkno := imap pos: Pos {:trigger} :: 0 as Blkno;
-      this.data := imap pos: Pos | pos.idx.data? :: block0;
+      this.data := imap pos: Pos | pos.idx.data?() :: block0;
       this.metadata := map ino: Ino {:trigger} :: Inode.Meta(0, Inode.InvalidType);
       new;
       assert ValidBasics() by { reveal fsValid(); }

--- a/src/Dafny/examples/fs/pos.dfy
+++ b/src/Dafny/examples/fs/pos.dfy
@@ -231,7 +231,12 @@ module IndirectPos
   datatype preIdx = Idx(k: uint64, off: IndOff)
   {
     const ilevel: uint64 := off.ilevel
-    const data?: bool := k as nat < |config.ilevels| && off.ilevel == config.ilevels[k]
+    predicate method data?()
+    {
+      && k as nat < |config.ilevels|
+      && off.ilevel == config.ilevels[k]
+    }
+
 
     static function from_inode(k: uint64): Idx
       requires k as nat < |config.ilevels|
@@ -248,7 +253,7 @@ module IndirectPos
     // "flat" indices are logical block addresses (LBAs) for the inode
     function flat(): uint64
       requires Valid()
-      requires this.data?
+      requires this.data?()
     {
       config.total_to(k) + off.j
     }
@@ -258,7 +263,7 @@ module IndirectPos
     // i.split() until we get a direct block)
     static function method from_flat(n: uint64): (i:Idx)
       requires n < config.total as uint64
-      ensures i.data?
+      ensures i.data?()
     {
       if n < 10 then
         Idx(n, IndOff.direct)
@@ -330,7 +335,7 @@ module IndirectPos
   datatype Pos = Pos(ino: Ino, idx: Idx)
   {
     const ilevel: uint64 := idx.off.ilevel;
-    const data?: bool := idx.data?
+    const data?: bool := idx.data?()
 
     static function method from_flat(ino: Ino, n: uint64): Pos
       requires n as nat < config.total


### PR DESCRIPTION
I spent several hours investigating solver performance of `dir_fs.dfy`. I believe the following two changes significantly improve quality of life:
1. make `extend_zero` opaque
2. avoid using `const` in one weird place

(These changes are in commit `42c02f9`.)

These changes cause the functions in `dir_fs.dfy` not to timeout when things are wrong. (I only checked `growInodeFor`, `CREATE`, and `WRITEgeneral`.) The changes also seem to improve performance even when the code is correct.

Performance does not improve if either change is made independently, as far as I can tell.

Unfortunately, the second change breaks verification of `deleteAt` in `mem_dirent.dfy`. I don't know why, except to say that this proof is quite fragile. Just to convince you that it has nothing to do with me, I pushed a second commit (`29ddc24`) that is a really verbose rephrasing of the existing proof, but which passes. It's a separate issue to debug this fragility, but I don't think it's very closely related to these changes.

Change 1 is fairly straightforward. I discovered it by dumping to Boogie and manually delta debugging subject to maintaining a 20 second timeout. The resulting file mentioned the definition of `extend_zero`, so I guessed it was worth making opaque.

Change 2 is weirder. I haven't written much Dafny recently, so I'm not super familiar with `const`, but when I was digging around in the Boogie layer, the trigger assigned to the type axiom for this constant was sort of worrying looking. It used a Boogie inline function which expanded to a big expression containing lots of interpreted symbols. My guess is that Z3 silently rejected this trigger, decided to infer its own trigger, and picked something absolutely terrible, which caused performance problems. Perhaps we can get @RustanLeino to investigate. 

Let me know what you think. I don't think you should merge my second commit with the bad proof fix. Instead, see if you like my first commit, and if so, use your own knowledge to fix the proof of `deleteAt`.

Happy to discuss further!

James